### PR TITLE
Deploy.yaml: Proceed once .NET starts

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -34,7 +34,9 @@ jobs:
           SERVER_PID=$!
 
           # Wait a moment to ensure server is up
-          sleep 60
+          while ! nc -z localhost 5126; do
+            sleep 1
+          done
 
           # Run Deno script with error handling
           deno -A jsr:@etok/sparchive@0.0.2 --entrypoint="http://localhost:5126/" --output="build" || {


### PR DESCRIPTION
### Background

If there is some way to proceed once the server starts instead of assuming it starts at least within the first 60 seconds that could potentially improve the speed.

### Changes

- Adds `while` statement that breaks once .NET is detected.